### PR TITLE
Remoção do botão de voltar

### DIFF
--- a/lib/screens/new_culture.dart
+++ b/lib/screens/new_culture.dart
@@ -43,11 +43,6 @@ class _NewCultureScreenState extends State<NewCultureScreen> {
       onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
       child: Scaffold(
         appBar: AppBar(
-          leading: IconButton(
-            icon: Icon(Icons.arrow_back_outlined),
-            color: Color(0xffffffff),
-            onPressed: () {},
-          ),
           title: Text(
             'Adicionar Cultura',
             style: TextStyle(color: Color(0xffffffff)),


### PR DESCRIPTION
Não é necessário um botão de voltar explícito na tela de cadastro de cultura, já que **o próprio app adiciona-o** quando é utilizado o método `Navigator.push`. Por este motivo, esse botão **foi excluído**.